### PR TITLE
fix back button not re-locking unlocked top rows

### DIFF
--- a/src/main.gd
+++ b/src/main.gd
@@ -433,11 +433,15 @@ func highlight_empty_space(on:bool):
 			bottom_space.get_node("Icon").visible = on
 
 func unlock_next_space():
+	# gdscript is lazy, so if we don't make a new array, any changes we make
+	# will change the history
+	unlocked_slots = unlocked_slots.duplicate()
+	
 	for n in len(unlocked_slots):
 		if not unlocked_slots[n]:
 			unlocked_slots[n] = true
-			return
-	
+			break
+
 func close_stack(stack:Area2D,is_loading=false):
 	print_debug("CLOSING")
 	if not is_loading and not stack.is_in_group("only_one"):


### PR DESCRIPTION
This fixes a bug on medium or harder that allows one to unlock all upper slots without committing to any lower slots being locked. 

To recreate:
Start game on medium or harder
Complete stack of four on empty square to unlock upper slot
Hit back button
Note that newly unlocked upper slot is still unlocked
On harder difficulties, repeat to unlock all upper slots

Cause and fix:
gdscript seems to be a lazy copy language like python. So when you push unlocked_slots to history, it pushes the object reference, not the values, to the history. This means that whenever changes happen to unlocked_slots, it changes all references. To fix this, we make a new copy every time we edit unlocked_slots, which is only in "unlock_next_space"